### PR TITLE
Fix copy and rename detection for hg

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,10 @@
                             case 'deleted':
                                 break;
                             case 'copy':
+                                currentInfoType = 'copy'
+                                break;
+                            case 'rename':
+                                currentInfoType = 'rename'
                                 break;
                             case '---':
                                 var oldPath = segs[1];
@@ -152,7 +156,6 @@
                                     currentInfo.oldPath = '/dev/null';
                                     currentInfoType = 'add';
                                 } else {
-                                    currentInfoType = 'modify';
                                     currentInfo.oldPath = oldPath.slice(2);
                                 }
 
@@ -168,10 +171,6 @@
 
                                 stat = STAT_HUNK;
                                 break simiLoop;
-                        }
-
-                        if (!currentInfoType) {
-                            currentInfoType = segs[0];
                         }
                     }
 

--- a/test/hg/cp.diff
+++ b/test/hg/cp.diff
@@ -1,3 +1,5 @@
 diff --git a/a.txt b/b.txt
 copy from a.txt
 copy to b.txt
+--- a/a.txt
++++ b/b.txt

--- a/test/hg/mv.diff
+++ b/test/hg/mv.diff
@@ -1,3 +1,5 @@
 diff --git a/b.txt b/c.txt
 rename from b.txt
 rename to c.txt
+--- a/b.txt
++++ b/c.txt


### PR DESCRIPTION
## Proposed changes

When files were changed additionally to the copy/rename,
the type has always been set to 'modify' despite of copy
or rename tags.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
